### PR TITLE
Add Docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang
+
+RUN \
+  apt update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+      libmpv-dev \
+      python-pip \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN \
+  pip install --no-cache youtube-dl \
+  && youtube-dl --version
+
+WORKDIR ${GOPATH}/src/github.com/aykevl/plaincast/
+COPY . ${GOPATH}/src/github.com/aykevl/plaincast/
+
+RUN go get -v .
+RUN go install -i .
+
+ENTRYPOINT [ "plaincast" ]

--- a/README.md
+++ b/README.md
@@ -77,8 +77,20 @@ Or for Python 3:
     $ sudo pip3 install --upgrade youtube-dl
 
 It is advisable to run this regularly as it has to keep up with YouTube updates.
-Certainly first try updating youtube-dl when plaincast stops working.
+Certainly first try updating `youtube-dl` when plaincast stops working.
 
+## Docker
+
+Both `Dockerfile` and Docker Compose manifest are provided. The former builds
+a Docker image with the program binary built from local code and the required
+build dependencies. The Docker image also includes a recent `youtube-dl`
+version. This will avoid the need of installing a recent version for the local
+OS and version on the host, thus avoiding the risks of installing any software.
+The [Docker Compose manifest](./docker-compose.yml) contains the configuration
+settings needed to launch a Docker container.
+To run the Docker image, just run:
+
+    $ docker-compose up --build --force-recreate
 
 ## Known issues
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,3 @@ services:
     network_mode: host
     devices:
       - /dev/snd
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2.4"
+services:
+  plaincast:
+    container_name: plaincast
+    restart: unless-stopped
+    build: .
+    environment:
+      - ALSA_CARD
+    network_mode: host
+    devices:
+      - /dev/snd
+
+


### PR DESCRIPTION
- Dockerfile initial version.
- Add Docker Compose manifest.
- Readme: document usage.

I've successfully used the provided files to locally build and run the app
from source without installing Golang, libs, `pip` or `youtube-dl`.
Everything is included in the built image.

The Docker Compose manifest will take care of building the image according
the `Dockerfile` and later launching a container with the appropriate
settings, mainly mounting the `/dev/snd` device and using `host` networking
mode to allow SSDP to work.

Most of the PR should be self-explanatory with the provided docs.
